### PR TITLE
Add Security Headers

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -10,11 +10,19 @@ map $sent_http_content_type $expires {
 server {
     listen       80;
     server_name  localhost;
+    server_tokens off;
 
     #charset koi8-r;
     #access_log  /var/log/nginx/log/host.access.log  main;
 
     location / {
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Xss-Protection "1; mode=block" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'none'; script-src 'self' 'sha256-N6VbmxPlg001d5gdjorH0+FmhZvteoL+vkB67ARafbM=' 'sha256-nP0EI9B9ad8IoFUti2q7EQBabcE5MS5v0nkvRfUbYnM=' www.google-analytics.com; style-src 'self'; frame-src www.youtube.com fast.wistia.com; img-src 'self'; font-src 'self'; report-uri https://purplebooth.report-uri.io/r/default/csp/enforce" always;
+
         if ($http_x_forwarded_proto = "http") {
           return 301 https://$host$request_uri;
         }
@@ -23,15 +31,21 @@ server {
         add_header Pragma public;
         add_header Cache-Control "public";
 
+
         root   /usr/share/nginx/html;
         index  index.html index.htm;
     }
 
     location /status {
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Xss-Protection "1; mode=block" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src none; report-uri https://purplebooth.report-uri.io/r/default/csp/enforce" always;
+
         stub_status;
     }
-
-    #error_page  404              /404.html;
 
     # redirect server error pages to the static page /50x.html
     #
@@ -39,27 +53,4 @@ server {
     location = /50x.html {
         root   /usr/share/nginx/html;
     }
-
-    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
-    #
-    #location ~ \.php$ {
-    #    proxy_pass   http://127.0.0.1;
-    #}
-
-    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
-    #
-    #location ~ \.php$ {
-    #    root           html;
-    #    fastcgi_pass   127.0.0.1:9000;
-    #    fastcgi_index  index.php;
-    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
-    #    include        fastcgi_params;
-    #}
-
-    # deny access to .htaccess files, if Apache's document root
-    # concurs with nginx's one
-    #
-    #location ~ /\.ht {
-    #    deny  all;
-    #}
 }


### PR DESCRIPTION
This adds security headers lost in the migration from Cloud Flare. This
should make it harder to be exploited by XSS vulns.