### PR TITLE
Enable HSTS Preload

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -16,7 +16,7 @@ server {
     #access_log  /var/log/nginx/log/host.access.log  main;
 
     location / {
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Xss-Protection "1; mode=block" always;
         add_header X-Content-Type-Options "nosniff" always;
@@ -37,12 +37,12 @@ server {
     }
 
     location /status {
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Xss-Protection "1; mode=block" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src none; report-uri https://purplebooth.report-uri.io/r/default/csp/enforce" always;
+        add_header Content-Security-Policy "default-src none" always;
 
         stub_status;
     }


### PR DESCRIPTION
HSTS is the great little response header that tells a browser to always
use SSL/TLS to communicate with your site. It doesn't matter if the
user, or a link they are clicking, specifies HTTP, HSTS will remove the
ability for a compatible browser to use HTTP and will enforce the use of
HTTPS. This still leaves a user vulnerable on their very first
connection to a site though. HSTS preloading fixes that.