### PR TITLE
Redirect www to bare domain

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -8,7 +8,19 @@ map $sent_http_content_type $expires {
 }
 
 server {
-    listen       80;
+    listen 80;
+    listen [::]:80;
+
+    server_name ~^www\.(?<domain>.+)$;
+
+    location / {
+      return 301 $scheme://$domain$request_uri;
+    }
+}
+
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server ipv6only=on;
     server_name  localhost;
     server_tokens off;
 


### PR DESCRIPTION
Currently users can go to www.purplebooth.co.uk and they get a broken
page. This isn't the best experience. This will redirect users to the
non-www page.